### PR TITLE
Update makefile.unix

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -161,7 +161,7 @@ DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 OBJS += obj/txdb-leveldb.o
 leveldb/libleveldb.a:
-	@echo "Building LevelDB ..."; cd leveldb; make libleveldb.a libmemenv.a; cd ..;
+	@echo "Building LevelDB ..."; cd leveldb; sudo make libleveldb.a libmemenv.a; cd ..;
 obj/txdb-leveldb.o: leveldb/libleveldb.a
 
 # auto-generated dependencies:


### PR DESCRIPTION
make libleveldb.a libmemenv.a;
will fail on a non root user installation.
